### PR TITLE
Add `desc` method to describe commands: `desc 'my_command param'`

### DIFF
--- a/lib/slackbotsy/bot.rb
+++ b/lib/slackbotsy/bot.rb
@@ -8,13 +8,16 @@ module Slackbotsy
 
   class Bot
 
+    attr_accessor :commands, :last_description
+
     def initialize(options)
       @options = options
 
       ## use set of tokens for (more or less) O(1) lookup on multiple channels
       @options['outgoing_token'] = Array(@options['outgoing_token']).to_set
-      @regexes = {}
+      @commands = []
       setup_incoming_webhook    # http connection for async replies
+      setup_help                # botsy help
       yield if block_given?     # run any hear statements in block
     end
 
@@ -52,7 +55,32 @@ module Slackbotsy
 
     ## add regex to things to hear
     def hear(regex, &block)
-      @regexes[regex] = block
+      ## allow multiple commands with the same regex
+      commands << OpenStruct.new(regex: regex, description: get_description, proc: block)
+    end
+
+    def desc(description)
+      @last_description = description
+    end
+
+    def get_description
+      desc = @last_description
+      @last_description = nil
+      desc
+    end
+
+    def setup_help
+      ## -v verbose desc => regex
+      hear /^help(\s\-.)?$/ do |mdata|
+        @caller.commands.reject { |cmd| cmd.description.nil? }.
+          map do |cmd|
+          if mdata[1].to_s.strip == '-v'
+            "#{cmd.description} => #{cmd.regex.inspect}"
+          else
+            cmd.description
+          end
+        end
+      end
     end
 
     ## pass list of files containing hear statements, to be opened and evaled
@@ -70,10 +98,10 @@ module Slackbotsy
 
       ## loop things to look for and collect immediate responses
       ## rescue everything here so the bot keeps running even with a broken script
-      responses = @regexes.map do |regex, proc|
-        if mdata = msg[:text].strip.match(regex)
+      responses = commands.map do |cmd|
+        if mdata = msg[:text].strip.match(cmd.regex)
           begin
-            Slackbotsy::Message.new(self, msg).instance_exec(mdata, &proc)
+            Slackbotsy::Message.new(self, msg).instance_exec(mdata, &cmd.proc)
           rescue => err
             err
           end


### PR DESCRIPTION
Add `desc` similar to Rake.

``` ruby
desc '[top N] (persist|delivery) [last N (minute|hour|day|weeks)]'
hear /^(top\s+(\d+)\s+)?(persist|delivery)(\s+(.+))?$/i do |mdata|
  # ...
end
```

``` bash
slack: help
[top N] (persist|delivery) [last N (minute|hour|day|weeks)]

slack: help -v
[top N] (persist|delivery) [last N (minute|hour|day|weeks)] => ^(top\s+(\d+)\s+)?(persist|delivery)(\s+(.+))?$
```
