### PR TITLE
Use the splat operator to simplify matching in hear blocks

### DIFF
--- a/lib/slackbotsy/bot.rb
+++ b/lib/slackbotsy/bot.rb
@@ -147,7 +147,7 @@ module Slackbotsy
       @listeners.map do |listener|
         text.match(listener.regex) do |mdata|
           begin
-            message.instance_exec(mdata, &listener.proc)
+            message.instance_exec(*mdata[1..-1], &listener.proc)
           rescue => err # keep running even with a broken script, but report the error
             err
           end


### PR DESCRIPTION
This makes it easier to reason with the `hear` blocks when matching regex. Right now its a bit cumbersome to do something like

``` ruby
hear /^wd @(\w+) (.*)/ do |mdata|
  "#well done @#{mdata[1]} for #{mdata[2]}"
end
```

Instead, this would now become

``` ruby
hear /^wd @(\w+) (.*)/ do |recipient, acheivement|
  "#well done @#{recipient} for #{acheivement}"
end
```
